### PR TITLE
Added method to do ZIP with array of arrays.

### DIFF
--- a/Underscore/USArrayWrapper.h
+++ b/Underscore/USArrayWrapper.h
@@ -58,6 +58,7 @@
 @property (readonly) USArrayWrapper *(^each)(UnderscoreArrayIteratorBlock block);
 @property (readonly) USArrayWrapper *(^map)(UnderscoreArrayMapBlock block);
 @property (readonly) USArrayWrapper *(^zipWith)(NSArray *array, UnderscoreArrayZipWithBlock block);
+@property (readonly) USArrayWrapper *zip;
 
 @property (readonly) USArrayWrapper *(^pluck)(NSString *keyPath);
 

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -245,8 +245,8 @@
 
 - (USArrayWrapper *)zip
 {
-    int lenght = [self.first count];
-    NSMutableArray *finalMutableArray = [NSMutableArray arrayWithCapacity:lenght*self.array.count];
+    int length = [self.first count];
+    NSMutableArray *finalMutableArray = [NSMutableArray arrayWithCapacity:lenght * self.array.count];
     for (NSUInteger index = 0; index < lenght; index++) {
         USArrayWrapper *wrapper = self.map(^id (id obj) {
             return [obj objectAtIndex:index];

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -243,6 +243,19 @@
     };
 }
 
+- (USArrayWrapper *)zip
+{
+    int lenght = [self.first count];
+    NSMutableArray *finalMutableArray = [NSMutableArray arrayWithCapacity:lenght*self.array.count];
+    for (NSUInteger index = 0; index < lenght; index++) {
+        USArrayWrapper *wrapper = self.map(^id (id obj) {
+            return [obj objectAtIndex:index];
+        });
+        [finalMutableArray addObject:wrapper.unwrap];
+    }
+    return [[USArrayWrapper alloc] initWithArray:finalMutableArray];
+}
+
 - (USArrayWrapper *(^)(NSString *))pluck
 {
     return ^USArrayWrapper *(NSString *keyPath) {

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -245,9 +245,9 @@
 
 - (USArrayWrapper *)zip
 {
-    int length = [self.first count];
-    NSMutableArray *finalMutableArray = [NSMutableArray arrayWithCapacity:lenght * self.array.count];
-    for (NSUInteger index = 0; index < lenght; index++) {
+    int length = (int)[self.first count];
+    NSMutableArray *finalMutableArray = [NSMutableArray arrayWithCapacity:length * self.array.count];
+    for (NSUInteger index = 0; index < length; index++) {
         USArrayWrapper *wrapper = self.map(^id (id obj) {
             return [obj objectAtIndex:index];
         });

--- a/Underscore/Underscore+Functional.h
+++ b/Underscore/Underscore+Functional.h
@@ -52,7 +52,7 @@
 + (void (^)(NSArray *array, UnderscoreArrayIteratorBlock block))arrayEach;
 + (NSArray *(^)(NSArray *array, UnderscoreArrayMapBlock block))arrayMap;
 + (NSArray *(^)(NSArray *firstArray, NSArray *secondArray, UnderscoreArrayZipWithBlock block))arrayZipWith;
-
++ (NSArray *(^)(NSArray *))zip;
 + (NSArray *(^)(NSArray *array, NSString *keyPath))pluck;
 
 + (NSArray *(^)(NSArray *array))uniq;

--- a/Underscore/Underscore+Functional.m
+++ b/Underscore/Underscore+Functional.m
@@ -142,6 +142,13 @@
     };
 }
 
++ (NSArray *(^)(NSArray *))zip
+{
+    return ^(NSArray *array) {
+        return Underscore.array(array).zip.unwrap;
+    };
+}
+
 + (NSArray *(^)(NSArray *, NSString *))pluck
 {
     return ^(NSArray *array, NSString *keyPath) {


### PR DESCRIPTION
#### :tophat: What? Why?

There is already a `zipWith` method but i think this one is more useful.
Zip an array of arrays.
this:

``` objc
@[@[@1, @2, @3], @[@4, @5, @6], @[@7, @8, @9]]
```

transforms into this:

``` objc
@[@[@1, @4, @7], @[@2, @5, @9], @[@3, @6, @9]]
```

:warning: all the arrays should have the same lenght
#### :ghost: GIF

![](http://media.giphy.com/media/elnOfetKsGDHa/giphy.gif)
