### PR TITLE
New feature: group objects in an array by the given key

### DIFF
--- a/Underscore/USArrayWrapper.h
+++ b/Underscore/USArrayWrapper.h
@@ -75,5 +75,6 @@
 @property (readonly) USArrayWrapper *(^sort)(UnderscoreSortBlock block);
 
 @property (readonly) USDictionaryWrapper *(^groupBy)(UnderscoreGroupingBlock block);
+@property (readonly) USArrayWrapper *(^groupByKey)(NSString *key);
 
 @end

--- a/Underscore/USArrayWrapper.m
+++ b/Underscore/USArrayWrapper.m
@@ -359,4 +359,22 @@
     };
 }
 
+- (USArrayWrapper *(^)(NSString *key))groupByKey
+{
+    return ^USArrayWrapper *(NSString *key) {
+        NSMutableArray *resultArray = [NSMutableArray new];
+        NSMutableArray *discarded = [NSMutableArray new];
+        
+        for (id object in self.array) {
+            if ([discarded containsObject:object]) { continue; }
+            id groupID = [object valueForKey:key];
+            NSArray *group = [self.array filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"%K = %@", key, groupID]];
+            [resultArray addObject:group];
+            [discarded addObjectsFromArray:group];
+        }
+        
+        return [USArrayWrapper wrap:resultArray];
+    };
+}
+
 @end

--- a/Underscore/Underscore+Functional.h
+++ b/Underscore/Underscore+Functional.h
@@ -68,6 +68,7 @@
 + (NSArray *(^)(NSArray *array, UnderscoreSortBlock block))sort;
 
 + (NSDictionary *(^)(NSArray *array, UnderscoreGroupingBlock block))groupBy;
++ (NSArray *(^)(NSArray *array, NSString *key))groupByKey;
 
 #pragma mark NSDictionary style methods
 

--- a/Underscore/Underscore+Functional.m
+++ b/Underscore/Underscore+Functional.m
@@ -203,6 +203,14 @@
     };
 }
 
++ (NSArray *(^)(NSArray *, NSString *))groupByKey
+{
+    return ^(NSArray *array, NSString *key) {
+        return Underscore.array(array).groupByKey(key).unwrap;
+    };
+}
+
+
 #pragma mark NSDictionary shortcuts
 
 + (USDictionaryWrapper *(^)(NSDictionary *))dict


### PR DESCRIPTION
#### :tophat: What? Why?

added new feature to Underscore, group an Array to an Array of Arrays using the given key.
Ex:

``` objc
NSArray *array = @[ N1, N2, N3, N4]; 
//where N1 and N3 have a property projectID = @1
//and N2 and N4 have a property projectID = @2

NSArray *result = _.groupByKey(array, @"projectID");
// result = @[@[N1, N3], @[N2, N4]];
```
#### :dart: What should QA test?
#### :pushpin: Related tasks?
#### :clipboard: Developer checklist
- [ ] Unit Tests (if necessary)
- [ ] UI Snapshot Tests (if necessary)
- [ ] Added accessibility tags to any interactive element
- [ ] Added reporting for GA (events + screen views) / Errors / Exceptions
- [ ] Documentation
#### :ghost: GIF

![](http://38.media.tumblr.com/8901b8b9edda31ad15a3532b2157577d/tumblr_mtsigfoX3q1qz5d0vo1_250.gif)
